### PR TITLE
Add support for asm_groups_to_display

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "sendgrid/smtpapi",
     "description": "Build SendGrid X-SMTPAPI headers in PHP.",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "homepage": "http://github.com/sendgrid/smtpapi-php",
     "license": "MIT",
     "keywords": ["SendGrid", "sendgrid", "email", "send", "grid", "smtpapi", "smtp", "api", "xsmtp", "X-SMTP"],

--- a/lib/Smtpapi/Header.php
+++ b/lib/Smtpapi/Header.php
@@ -14,6 +14,7 @@ class Header
     public $send_at = null;
     public $send_each_at = array();
     public $asm_group_id = null;
+    public $asm_groups_to_display = array();
     public $ipPool = null;
 
     /**
@@ -219,6 +220,17 @@ class Header
     }
 
     /**
+     * @param array $group_ids
+     * @return $this
+     */
+    public function setASMGroupsToDisplay(array $group_ids)
+    {
+        $this->asm_groups_to_display = $group_ids;
+
+        return $this;
+    }
+
+    /**
      * @param string $name
      * @return $this
      */
@@ -262,6 +274,9 @@ class Header
         }
         if ($this->asm_group_id) {
             $data['asm_group_id'] = $this->asm_group_id;
+        }
+        if ($this->asm_groups_to_display) {
+            $data['asm_groups_to_display'] = $this->asm_groups_to_display;
         }
         if ($this->ipPool) {
             $data['ip_pool'] = $this->ipPool;

--- a/test/Smtpapi/Header.php
+++ b/test/Smtpapi/Header.php
@@ -184,6 +184,14 @@ class SmtpapiTest_Header extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->t['set_asm_group_id'], $header->jsonString());
     }
 
+    public function testSetASMGroupsToDisplay()
+    {
+        $header = new Smtpapi\Header();
+
+        $header->setASMGroupsToDisplay(array(1, 2, 3));
+        $this->assertEquals($this->t['set_asm_groups_to_display'], $header->jsonString());
+    }
+
     public function testSetSections()
     {
         $header = new Smtpapi\Header();

--- a/test/smtpapi_test_strings.json
+++ b/test/smtpapi_test_strings.json
@@ -20,5 +20,6 @@
     "set_send_each_at": "{\"send_each_at\":[1409348513,1409348514,1409348515]}",
     "add_send_each_at": "{\"send_each_at\":[1409348513,1409348514,1409348515]}",
     "set_asm_group_id": "{\"asm_group_id\":2}",
+    "set_asm_groups_to_display": "{\"asm_groups_to_display\":[1,2,3]}",
     "set_ip_pool": "{\"ip_pool\":\"foo\"}"
 }


### PR DESCRIPTION
While you can currently specify a suppression group for an email, you cannot specify which suppression groups to display when the user clicks to manage their email preferences.