### PR TITLE
Removing global "minimum-stability" from Composer install

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,8 @@ Add the following to your `composer.json` file.
 
 ```json
 {
-    "minimum-stability" : "dev",
     "require": {
-        "sendgrid/smtpapi": "~0.5"
+        "sendgrid/smtpapi": "~0.5@dev"
     }
 }
 ```


### PR DESCRIPTION
That option should be set directly on the package and not globally for those how are working with multiple packages in Composer.