### PR TITLE
Swift Mailer production dependency removed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,13 @@
     "license": "MIT",
     "keywords": ["SendGrid", "sendgrid", "email", "send", "grid", "smtpapi", "smtp", "api", "xsmtp", "X-SMTP"],
     "require": {
-        "php": ">=5.6",
-        "swiftmailer/swiftmailer": "^5.4"
+        "php": ">=5.6"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"
+    },
+    "suggest": {
+        "swiftmailer/swiftmailer": "^5.4 - Needed to run the example scripts"
     },
     "replace": {
         "sendgrid/smtpapi-php": "*"


### PR DESCRIPTION
Now it's a `suggest` if some user needs to directly run the example scripts

Solves #27 