### PR TITLE
Add script for generating GitHub release notes

### DIFF
--- a/scripts/add-github-release-notes.php
+++ b/scripts/add-github-release-notes.php
@@ -80,7 +80,6 @@ try {
 
     echo 'Encoding the release notes'.PHP_EOL;
     $encoded = json_encode($data);
-    echo PHP_EOL;
 
     echo 'Sending content to the GitHub API:'.PHP_EOL;
     echo '> '.$encoded.PHP_EOL;

--- a/scripts/add-github-release-notes.php
+++ b/scripts/add-github-release-notes.php
@@ -1,0 +1,97 @@
+#!/usr/bin/php
+<?php
+
+/** @var string */
+const RELEASES_URI = 'https://api.github.com/repos/sendgrid/smtpapi-php/releases';
+/** @var string */
+$githubToken = getenv('GITHUB_TOKEN');
+
+/**
+ * @return array
+ * @throws Exception
+ */
+function parseLatestComponents()
+{
+    $changelog = file_get_contents(__DIR__.'/../CHANGELOG.md');
+
+    preg_match(
+        '/## \[(?<version>v[\d.]+?)\] - \((?<date>\d{4}-\d{2}-\d{2})\) ##\s(?<notes>[\s\S]+?)\s+## \[/m',
+        $changelog,
+        $info
+    );
+
+    if (isset($info['version']) && isset($info['date']) && isset($info['notes'])) {
+        return [
+            'version' => $info['version'],
+            'date'    => $info['date'],
+            'notes'   => $info['notes'],
+        ];
+    }
+
+    throw new Exception('Unable to parse the version!');
+}
+
+/**
+ * @param $data
+ * @param $githubToken
+ * @return bool
+ * @throws Exception
+ */
+function sendReleaseNotes($data, $githubToken)
+{
+    $curl = curl_init(RELEASES_URI);
+
+    curl_setopt_array(
+        $curl,
+        [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_POSTFIELDS     => $data,
+            CURLOPT_USERAGENT      => 'SendGrid',
+            CURLOPT_HTTPHEADER     => [
+                'authorization: token '.$githubToken,
+                'content-type: application/json',
+            ],
+        ]
+    );
+
+    curl_exec($curl);
+
+    $responseCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+
+    curl_close($curl);
+
+    if ($responseCode === 201) {
+        return true;
+    }
+
+    throw new Exception('An error occurred while creating the release notes.');
+}
+
+try {
+    if (!$githubToken) {
+        throw new Exception('No GitHub API token has been specified.');
+    }
+
+    echo 'Parsing the CHANGELOG components.'.PHP_EOL;
+    $components = parseLatestComponents();
+
+    echo 'Adding the release notes'.PHP_EOL;
+
+    $data = [
+        'tag_name' => $components['version'],
+        'name'     => $components['version'],
+        'body'     => $components['notes'],
+    ];
+
+    $encoded = json_encode($data);
+    echo PHP_EOL;
+
+    echo 'Sending content to the API:'.PHP_EOL;
+    echo '> '.$encoded.PHP_EOL;
+    sendReleaseNotes($encoded, $githubToken);
+
+    echo 'Successfully added release notes for release: '.$data['version'];
+    echo PHP_EOL;
+} catch (Exception $e) {
+    exit('ERROR: '.$e->getMessage());
+}

--- a/scripts/add-github-release-notes.php
+++ b/scripts/add-github-release-notes.php
@@ -25,8 +25,8 @@ function parseLatestComponents()
     if (isset($info['version']) && isset($info['body'])) {
         return [
             'tag_name' => $info['version'],
-            'name'    => $info['version'],
-            'body'   => $info['body'],
+            'name'     => $info['version'],
+            'body'     => $info['body'],
         ];
     }
 

--- a/scripts/add-github-release-notes.php
+++ b/scripts/add-github-release-notes.php
@@ -34,8 +34,9 @@ function parseLatestComponents()
 }
 
 /**
- * @param $data
- * @param $githubToken
+ * Send the release creation request to the GitHub API.
+ * @param $data The JSON-encoded array object
+ * @param $githubToken The GitHub API token
  * @return bool
  * @throws Exception
  */

--- a/scripts/add-github-release-notes.php
+++ b/scripts/add-github-release-notes.php
@@ -93,7 +93,7 @@ try {
     echo '> '.$encoded.PHP_EOL;
     sendReleaseNotes($encoded, $githubToken);
 
-    echo 'Successfully added release notes for release: '.$data['version'];
+    echo 'Successfully added release notes for release: '.$data['tag_name'];
     echo PHP_EOL;
 } catch (Exception $e) {
     exit('ERROR: '.$e->getMessage());

--- a/scripts/add-github-release-notes.php
+++ b/scripts/add-github-release-notes.php
@@ -15,18 +15,18 @@ function parseLatestComponents()
 {
     $changelog = file_get_contents(__DIR__.'/../CHANGELOG.md');
 
-    // Parse the latest CHANGELOG contents to 'version', 'date', and 'notes'
+    // Parse the latest CHANGELOG contents to 'tag_name', 'name', and 'body'
     preg_match(
-        '/## \[(?<version>v[\d.]+?)\] - \((?<date>\d{4}-\d{2}-\d{2})\) ##\s(?<notes>[\s\S]+?)\s+## \[/m',
+        '/## \[(?<version>v[\d.]+?)\] - \((\d{4}-\d{2}-\d{2})\) ##\s(?<body>[\s\S]+?)\s+## \[/m',
         $changelog,
         $info
     );
 
-    if (isset($info['version']) && isset($info['date']) && isset($info['notes'])) {
+    if (isset($info['version']) && isset($info['body'])) {
         return [
-            'version' => $info['version'],
-            'date'    => $info['date'],
-            'notes'   => $info['notes'],
+            'tag_name' => $info['version'],
+            'name'    => $info['version'],
+            'body'   => $info['body'],
         ];
     }
 
@@ -76,20 +76,13 @@ try {
     }
 
     echo 'Parsing the CHANGELOG components.'.PHP_EOL;
-    $components = parseLatestComponents();
+    $data = parseLatestComponents();
 
-    echo 'Adding the release notes'.PHP_EOL;
-
-    $data = [
-        'tag_name' => $components['version'],
-        'name'     => $components['version'],
-        'body'     => $components['notes'],
-    ];
-
+    echo 'Encoding the release notes'.PHP_EOL;
     $encoded = json_encode($data);
     echo PHP_EOL;
 
-    echo 'Sending content to the API:'.PHP_EOL;
+    echo 'Sending content to the GitHub API:'.PHP_EOL;
     echo '> '.$encoded.PHP_EOL;
     sendReleaseNotes($encoded, $githubToken);
 

--- a/scripts/add-github-release-notes.php
+++ b/scripts/add-github-release-notes.php
@@ -7,6 +7,7 @@ const RELEASES_URI = 'https://api.github.com/repos/sendgrid/smtpapi-php/releases
 $githubToken = getenv('GITHUB_TOKEN');
 
 /**
+ * Parse the CHANGELOG to retrieve the latest details.
  * @return array
  * @throws Exception
  */
@@ -14,6 +15,7 @@ function parseLatestComponents()
 {
     $changelog = file_get_contents(__DIR__.'/../CHANGELOG.md');
 
+    // Parse the latest CHANGELOG contents to 'version', 'date', and 'notes'
     preg_match(
         '/## \[(?<version>v[\d.]+?)\] - \((?<date>\d{4}-\d{2}-\d{2})\) ##\s(?<notes>[\s\S]+?)\s+## \[/m',
         $changelog,

--- a/scripts/add-github-release-notes.php
+++ b/scripts/add-github-release-notes.php
@@ -30,7 +30,7 @@ function parseLatestComponents()
         ];
     }
 
-    throw new Exception('Unable to parse the version!');
+    throw new Exception('Unable to parse the CHANGELOG for the latest version!');
 }
 
 /**


### PR DESCRIPTION
Closes #101 

----

I have marked this as WIP due to it requiring an environment variable (`GITHUB_TOKEN`) and I'm not sure if this should be run from Travis CI. I guess alternatively, it could prompt the user for a token if one isn't available in the environment.

----

It could probably do with a bit of refactoring as I finalise it, but in it's current state it is working as expected in a test repository.

### Checklist
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Added a script for creating GitHub releases (with notes) from the changes in the [`CHANGELOG.md`](https://github.com/sendgrid/smtpapi-php/blob/master/CHANGELOG.md) file

### Testing

I have tested this on my repository using the `v0.6.1` tag ([output release here](https://github.com/pxgamer/smtpapi-php/releases/tag/v0.6.1))
![Example output](https://image.prntscr.com/image/mzz__SxLQYOK0ZtdATz0Rg.png)

----

If this seems ok, I'd be happy to replicate this for sendgrid/sendgrid-php#750 as well. 👍